### PR TITLE
[iOS][#38] 이미지 캐싱 기능을 구현하여 풀리퀘스트 보냅니다

### DIFF
--- a/iOS/Sidedish/Sidedish.xcodeproj/project.pbxproj
+++ b/iOS/Sidedish/Sidedish.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		5A8211682450411E00308665 /* EventBadgeStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8211672450411E00308665 /* EventBadgeStackView.swift */; };
 		5A82116A2450421B00308665 /* EventBadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A8211692450421B00308665 /* EventBadgeLabel.swift */; };
 		5ACD1A93245707DB001BDCF5 /* CategoryURLsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACD1A92245707DB001BDCF5 /* CategoryURLsUseCase.swift */; };
+		5ACD1A962457E770001BDCF5 /* ImageUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACD1A952457E770001BDCF5 /* ImageUseCase.swift */; };
 		5AFDE97D24515C24004A7BB8 /* SuccessCategoryURLsResponseStub.json in Resources */ = {isa = PBXBuildFile; fileRef = 5AFDE97A24515C24004A7BB8 /* SuccessCategoryURLsResponseStub.json */; };
 		5AFDE97E24515C24004A7BB8 /* SuccessProductDetailResponseStub.json in Resources */ = {isa = PBXBuildFile; fileRef = 5AFDE97B24515C24004A7BB8 /* SuccessProductDetailResponseStub.json */; };
 		5AFDE97F24515C24004A7BB8 /* SuccessCategoryResponseStub.json in Resources */ = {isa = PBXBuildFile; fileRef = 5AFDE97C24515C24004A7BB8 /* SuccessCategoryResponseStub.json */; };
@@ -108,6 +109,7 @@
 		5A8211672450411E00308665 /* EventBadgeStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventBadgeStackView.swift; sourceTree = "<group>"; };
 		5A8211692450421B00308665 /* EventBadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventBadgeLabel.swift; sourceTree = "<group>"; };
 		5ACD1A92245707DB001BDCF5 /* CategoryURLsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryURLsUseCase.swift; sourceTree = "<group>"; };
+		5ACD1A952457E770001BDCF5 /* ImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUseCase.swift; sourceTree = "<group>"; };
 		5AFDE97A24515C24004A7BB8 /* SuccessCategoryURLsResponseStub.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SuccessCategoryURLsResponseStub.json; sourceTree = "<group>"; };
 		5AFDE97B24515C24004A7BB8 /* SuccessProductDetailResponseStub.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SuccessProductDetailResponseStub.json; sourceTree = "<group>"; };
 		5AFDE97C24515C24004A7BB8 /* SuccessCategoryResponseStub.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SuccessCategoryResponseStub.json; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 			children = (
 				5A446B88245581880004A9BC /* CategoryUseCase.swift */,
 				5ACD1A92245707DB001BDCF5 /* CategoryURLsUseCase.swift */,
+				5ACD1A952457E770001BDCF5 /* ImageUseCase.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -186,6 +189,7 @@
 		5A742732244E9D5F004144C1 /* Sidedish */ = {
 			isa = PBXGroup;
 			children = (
+				5ACD1A942457E57A001BDCF5 /* DataSource */,
 				5A446B87245581330004A9BC /* UseCases */,
 				5A742764244EA365004144C1 /* ViewControllers */,
 				5A742763244EA358004144C1 /* Views */,
@@ -302,6 +306,14 @@
 			path = "Login's";
 			sourceTree = "<group>";
 		};
+		5ACD1A942457E57A001BDCF5 /* DataSource */ = {
+			isa = PBXGroup;
+			children = (
+				5A789D76245410F80047DE7C /* CategoryViewModels.swift */,
+			);
+			path = DataSource;
+			sourceTree = "<group>";
+		};
 		5AFDE97924515C14004A7BB8 /* Network */ = {
 			isa = PBXGroup;
 			children = (
@@ -352,7 +364,6 @@
 				5AFDE9AA2451907E004A7BB8 /* ViewModelBinding.swift */,
 				5AFDE9AE24519564004A7BB8 /* ProductViewModel.swift */,
 				5A789D742452F7A50047DE7C /* CategoryViewModel.swift */,
-				5A789D76245410F80047DE7C /* CategoryViewModels.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -525,6 +536,7 @@
 				5A82115B2450004A00308665 /* PriceLabel.swift in Sources */,
 				5A7427B2244F0055004144C1 /* ProductCell.swift in Sources */,
 				5A7427A7244EC5BE004144C1 /* LoginViewController.swift in Sources */,
+				5ACD1A962457E770001BDCF5 /* ImageUseCase.swift in Sources */,
 				5A742736244E9D5F004144C1 /* SceneDelegate.swift in Sources */,
 				5A821153244FF7E200308665 /* ProductImageView.swift in Sources */,
 			);

--- a/iOS/Sidedish/Sidedish/DataSource/CategoryViewModels.swift
+++ b/iOS/Sidedish/Sidedish/DataSource/CategoryViewModels.swift
@@ -48,6 +48,13 @@ extension CategoryViewModels: UITableViewDataSource {
         }
         
         productViewModel.performBind { product in
+            ImageUseCase.imageData(from: product.image) { imageData in
+                guard let imageData = imageData else { return }
+                DispatchQueue.main.async {
+                    guard let productCell = tableView.cellForRow(at: indexPath) as? ProductCell else { return }
+                    productCell.configureImage(data: imageData)
+                }
+            }
             productCell.configureTitle(text: product.title)
             productCell.configureSubtitle(text: product.description)
             productCell.configureEventBadges(badges: product.badge)

--- a/iOS/Sidedish/Sidedish/DataSource/CategoryViewModels.swift
+++ b/iOS/Sidedish/Sidedish/DataSource/CategoryViewModels.swift
@@ -50,10 +50,7 @@ extension CategoryViewModels: UITableViewDataSource {
         productViewModel.performBind { product in
             ImageUseCase.imageData(from: product.image) { imageData in
                 guard let imageData = imageData else { return }
-                DispatchQueue.main.async {
-                    guard let productCell = tableView.cellForRow(at: indexPath) as? ProductCell else { return }
-                    productCell.configureImage(data: imageData)
-                }
+                self.configureImageIfExistCell(tableView, cellForRowAt: indexPath, imageData: imageData)
             }
             productCell.configureTitle(text: product.title)
             productCell.configureSubtitle(text: product.description)
@@ -66,6 +63,13 @@ extension CategoryViewModels: UITableViewDataSource {
                                   unitText: ProductViewModel.unitText)
         }
         return productCell
+    }
+
+    func configureImageIfExistCell(_ tableView: UITableView, cellForRowAt indexPath: IndexPath, imageData: Data) {
+        DispatchQueue.main.async {
+            guard let productCell = tableView.cellForRow(at: indexPath) as? ProductCell else { return }
+            productCell.configureImage(data: imageData)
+        }
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {

--- a/iOS/Sidedish/Sidedish/Info.plist
+++ b/iOS/Sidedish/Sidedish/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>UIAppFonts</key>

--- a/iOS/Sidedish/Sidedish/UseCases/ImageUseCase.swift
+++ b/iOS/Sidedish/Sidedish/UseCases/ImageUseCase.swift
@@ -1,0 +1,41 @@
+//
+//  ImageUseCase.swift
+//  Sidedish
+//
+//  Created by kimdo2297 on 2020/04/28.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+struct ImageUseCase {
+    static func imageData(from urlString: String,  completionHandler: @escaping (Data?) -> ()) {
+        guard let imageURL = URL(string: urlString),
+            let destinaionURL = try? FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false).appendingPathComponent(imageURL.lastPathComponent) else { return }
+        
+        if let imageData = try? Data(contentsOf: destinaionURL) {
+            completionHandler(imageData)
+        } else {
+            Self.downloadImageData(requestURL: imageURL, destinationURL: destinaionURL) { imageData in
+                guard let imageData = imageData else { return }
+                completionHandler(imageData)
+            }
+        }
+    }
+    
+    private static func downloadImageData(requestURL: URL, destinationURL: URL,
+                                  completionHandler: @escaping (Data?) -> ()) {
+        URLSession.shared.downloadTask(with: requestURL) { (tempURL, urlResponse, error) in
+            guard let tempURL = tempURL else { return }
+            do {
+                guard let imageData = try? Data(contentsOf: tempURL) else { return }
+                completionHandler(imageData)
+                try FileManager.default.moveItem(at: tempURL, to: destinationURL)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }.resume()
+    }
+    
+}
+

--- a/iOS/Sidedish/Sidedish/ViewModels/ProductViewModel.swift
+++ b/iOS/Sidedish/Sidedish/ViewModels/ProductViewModel.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Jason. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 final class ProductViewModel: ViewModelBinding {
     typealias Key = Product

--- a/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductCell.swift
+++ b/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductCell.swift
@@ -50,6 +50,7 @@ final class ProductCell: UITableViewCell, ReusableView {
             eventBadgeStackView.removeArrangedSubview(arrangedSubview)
             arrangedSubview.removeFromSuperview()
         }
+        productImageView.image = nil
     }
     
     private func configureProductImageView() {

--- a/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductCell.swift
+++ b/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductCell.swift
@@ -56,8 +56,9 @@ final class ProductCell: UITableViewCell, ReusableView {
         contentView.addSubview(productImageView)
         
         productImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,
-                                                  constant: 0).isActive = true
-        productImageView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+                                                  constant: 10).isActive = true
+        productImageView.topAnchor.constraint(equalTo: contentView.topAnchor,
+                                              constant: 10).isActive = true
         productImageView.heightAnchor.constraint(equalTo: contentView.heightAnchor,
                                                  multiplier: 1).isActive = true
         productImageView.widthAnchor.constraint(equalTo: productImageView.heightAnchor,
@@ -69,7 +70,7 @@ final class ProductCell: UITableViewCell, ReusableView {
         
         titleLabel.heightAnchor.constraint(equalToConstant: titleLabel.intrinsicContentSize.height).isActive = true
         titleLabel.leadingAnchor.constraint(equalTo: productImageView.trailingAnchor,
-                                            constant: 0).isActive = true
+                                            constant: 10).isActive = true
         titleLabel.topAnchor.constraint(equalTo: productImageView.topAnchor,
                                         constant: 15).isActive = true
         titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10).isActive = true
@@ -80,7 +81,7 @@ final class ProductCell: UITableViewCell, ReusableView {
         
         subTitleLabel.heightAnchor.constraint(equalToConstant: titleLabel.intrinsicContentSize.height).isActive = true
         subTitleLabel.leadingAnchor.constraint(equalTo: productImageView.trailingAnchor,
-                                               constant: 0).isActive = true
+                                               constant: 10).isActive = true
         subTitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor,
                                            constant: 2).isActive = true
         subTitleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,
@@ -92,7 +93,7 @@ final class ProductCell: UITableViewCell, ReusableView {
         
         normalPriceLabel.heightAnchor.constraint(equalToConstant: titleLabel.intrinsicContentSize.height).isActive = true
         normalPriceLabel.leadingAnchor.constraint(equalTo: productImageView.trailingAnchor,
-                                                  constant: 0).isActive = true
+                                                  constant: 10).isActive = true
         normalPriceLabel.topAnchor.constraint(equalTo: subTitleLabel.bottomAnchor,
                                               constant: 8).isActive = true
     }
@@ -110,11 +111,16 @@ final class ProductCell: UITableViewCell, ReusableView {
         contentView.addSubview(eventBadgeStackView)
         
         eventBadgeStackView.leadingAnchor.constraint(equalTo: productImageView.trailingAnchor,
-                                                     constant: 0).isActive = true
+                                                     constant: 10).isActive = true
         eventBadgeStackView.topAnchor.constraint(equalTo: normalPriceLabel.bottomAnchor,
                                                  constant: 8).isActive = true
         eventBadgeStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
-                                                    constant: -20).isActive = true
+                                                    constant: -10).isActive = true
+    }
+    
+    func configureImage(data: Data) {
+        guard let image = UIImage(data: data) else { return }
+        productImageView.image = image
     }
     
     func configureTitle(text: String) {

--- a/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductCell.swift
+++ b/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductCell.swift
@@ -118,6 +118,8 @@ final class ProductCell: UITableViewCell, ReusableView {
     func configureImage(data: Data) {
         guard let image = UIImage(data: data) else { return }
         productImageView.image = image
+        productImageView.layer.cornerRadius = productImageView.frame.size.width / 2
+        productImageView.clipsToBounds = true
     }
     
     func configureTitle(text: String) {

--- a/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductCell.swift
+++ b/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductCell.swift
@@ -59,10 +59,7 @@ final class ProductCell: UITableViewCell, ReusableView {
                                                   constant: 10).isActive = true
         productImageView.topAnchor.constraint(equalTo: contentView.topAnchor,
                                               constant: 10).isActive = true
-        productImageView.heightAnchor.constraint(equalTo: contentView.heightAnchor,
-                                                 multiplier: 1).isActive = true
-        productImageView.widthAnchor.constraint(equalTo: productImageView.heightAnchor,
-                                                multiplier: 1).isActive = true
+        productImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10).isActive = true
     }
     
     private func configureTitleLabel() {
@@ -114,8 +111,7 @@ final class ProductCell: UITableViewCell, ReusableView {
                                                      constant: 10).isActive = true
         eventBadgeStackView.topAnchor.constraint(equalTo: normalPriceLabel.bottomAnchor,
                                                  constant: 8).isActive = true
-        eventBadgeStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor,
-                                                    constant: -10).isActive = true
+        eventBadgeStackView.bottomAnchor.constraint(equalTo: productImageView.bottomAnchor).isActive = true
     }
     
     func configureImage(data: Data) {

--- a/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductImageView.swift
+++ b/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductImageView.swift
@@ -9,10 +9,6 @@
 import UIKit
 
 final class ProductImageView: UIImageView {
-    enum Images {
-        static let `default` = UIImage(systemName: "link.circle")
-    }
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
@@ -25,7 +21,8 @@ final class ProductImageView: UIImageView {
     
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = false
-        tintColor = .lightGray
+        widthAnchor.constraint(equalTo: heightAnchor,
+                               multiplier: 1).isActive = true
         contentMode = .scaleAspectFill
     }
 }

--- a/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductImageView.swift
+++ b/iOS/Sidedish/Sidedish/Views/Menu's/Cell/ProductImageView.swift
@@ -26,6 +26,6 @@ final class ProductImageView: UIImageView {
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = false
         tintColor = .lightGray
-        image = Images.default
+        contentMode = .scaleAspectFill
     }
 }


### PR DESCRIPTION
이슈 #38 을 해결하였습니다.

* ImageUseCase 객체가 imageData를 ProductCell에 넘겨주는 형식으로 구조를 작성하였습니다. 
  * 캐시 디렉토리에 해당 사진이 있으면 `Data(contentsOf: )`을 이용해 사진 데이터를 넘겨주고, 
  * 해당 사진이 캐시 디렉토리에 없으면 downloadTask로 해당 이미지 데이터를 다운로드하여 사진 데이터를 넘겨주고, 해당 사진을 캐시 디렉토리에 저장하도록 하였습니다. 

* 이미지 데이터를 서버로부터 로드하는 것은 시간이 오래 걸리는 작업이기 때문에 다운로드 받는 시간보다 스크롤하여 해당 행이 없어지는 것이 더 빠를 수 있습니다. 따라서 해당 셀이 이후의 행에서 재활용되는 경우 이 때 이전에 다른 행에서 로드하려고 했던 이미지가 보여질 수 있습니다.
  * 이를 방지하기 위해 `tableView.cellForRow`을 이용해 해당 행이 사진이 다운로드된 경우에도 계속 있는 경우에만 image가 보여지도록 하였습니다. 
  * 이를 방지하기 위해 `prepareForReuse`를 사용해 이미지뷰의 이미지를 nil로 초기화 하였습니다.

> 실행화면

<img src="https://user-images.githubusercontent.com/38216027/80453243-d74a6a00-8962-11ea-9d1d-d0f788641ce0.png" height="500" alt="이미지 캐싱" />
