### PR TITLE
[iOS] 비동기 async 코드를 Mock 객체 내부 메소드로 이동시켰습니다.

### DIFF
--- a/iOS/Sidedish/Sidedish/Network/Mocks/MockCategoryURLsSuccess.swift
+++ b/iOS/Sidedish/Sidedish/Network/Mocks/MockCategoryURLsSuccess.swift
@@ -9,10 +9,15 @@
 import Foundation
 
 struct MockCategoryURLsSuccess: NetworkManagable {
+    private let queue = DispatchQueue(label: "mockCategory")
+    
     func requestResource(from urlString: String,
                          httpMethod: HTTPMethod, httpBody: Data?,
                          completionHandler: @escaping (Data?, URLResponse?, Error?) -> ()) throws {
         guard let data = Data.jsonData(forResource: "SuccessCategoryURLsResponseStub") else { return }
-        completionHandler(data, nil, nil)
+        
+        queue.async {
+            completionHandler(data, nil, nil)
+        }
     }
 }

--- a/iOS/Sidedish/Sidedish/ViewControllers/CategoryViewController.swift
+++ b/iOS/Sidedish/Sidedish/ViewControllers/CategoryViewController.swift
@@ -18,9 +18,7 @@ final class CategoryViewController: UIViewController {
         super.viewDidLoad()
         configureMenuTableView()
         configureObserver()
-        DispatchQueue.init(label: "mockCategory").asyncAfter(wallDeadline: .now() + 0.5) {
-            self.configureUsecase()
-        }
+        configureUsecase()
     }
     
     private func configureMenuTableView() {


### PR DESCRIPTION
* 비동기 async 코드를 Mock 객체 내부 메소드로 이동시키기
> Issue #57 를 구현하였습니다.