### PR TITLE
[iOS][hotfix] reloadData로 섹션 count를 업데이트 해줘서 런타임 에러나는 것 해결

### DIFF
--- a/iOS/Sidedish/Sidedish/DataSource/CategoryViewModels.swift
+++ b/iOS/Sidedish/Sidedish/DataSource/CategoryViewModels.swift
@@ -13,10 +13,12 @@ import RxCocoa
 
 final class CategoryViewModels: NSObject {
     enum Notification {
+        static let categorysCountDidChange =
+            Foundation.Notification.Name("categorysCountDidChange")
         static let categoryViewModelsDidChange = Foundation.Notification.Name("categoryViewModelsDidChange")
     }
     
-    private var count: Int?
+    private var count = 0
     private var categoryViewModels: [Int: CategoryViewModel]
     private var disposeBag = DisposeBag()
     
@@ -26,6 +28,10 @@ final class CategoryViewModels: NSObject {
     
     func set(count: Int) {
         self.count = count
+        NotificationCenter.default.post(
+            name: Notification.categorysCountDidChange,
+            object: self
+        )
     }
     
     func categoryViewModel(at index: Int) -> CategoryViewModel? {
@@ -35,8 +41,11 @@ final class CategoryViewModels: NSObject {
     
     func insert(at index: Int, categoryViewModel: CategoryViewModel) {
         categoryViewModels[index] = categoryViewModel
-        NotificationCenter.default.post(name: Notification.categoryViewModelsDidChange,
-                                        object: self, userInfo: ["index": index])
+        NotificationCenter.default.post(
+            name: Notification.categoryViewModelsDidChange,
+            object: self,
+            userInfo: ["index": index]
+        )
     }
 }
 
@@ -71,6 +80,6 @@ extension CategoryViewModels: UITableViewDataSource {
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {
-        return count ?? 0
+        return count
     }
 }

--- a/iOS/Sidedish/Sidedish/Network/Mocks/MockCategoryURLsSuccess.swift
+++ b/iOS/Sidedish/Sidedish/Network/Mocks/MockCategoryURLsSuccess.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 struct MockCategoryURLsSuccess: NetworkManagable {
-    private let queue = DispatchQueue(label: "mockCategory")
+    private let queue = DispatchQueue(label: "mockURLCategory")
     
     func requestResource(from urlString: String,
                          httpMethod: HTTPMethod, httpBody: Data?,
                          completionHandler: @escaping (Data?, URLResponse?, Error?) -> ()) throws {
         guard let data = Data.jsonData(forResource: "SuccessCategoryURLsResponseStub") else { return }
         
-        queue.async {
+        queue.asyncAfter(deadline: .now() + 1) {
             completionHandler(data, nil, nil)
         }
     }

--- a/iOS/Sidedish/Sidedish/ViewControllers/CategoryViewController.swift
+++ b/iOS/Sidedish/Sidedish/ViewControllers/CategoryViewController.swift
@@ -21,7 +21,7 @@ final class CategoryViewController: UIViewController {
         super.viewDidLoad()
         
         configureMenuTableView()
-        configureObserver()
+        configureObservers()
         configureURLUsecase()
     }
     
@@ -55,16 +55,28 @@ final class CategoryViewController: UIViewController {
             multiplier: 1).isActive = true
     }
     
-    private func configureObserver() {
+    private func configureObservers() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(updateTableView),
+            name: CategoryViewModels.Notification.categorysCountDidChange,
+            object: categoryViewModels)
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateTableViewSection),
             name: CategoryViewModels.Notification.categoryViewModelsDidChange,
             object: categoryViewModels
         )
     }
     
-    @objc private func updateTableView(notification: Notification) {
+    @objc private func updateTableView() {
+        DispatchQueue.main.async {
+            self.categoryTableView.reloadData()
+        }
+    }
+    
+    @objc private func updateTableViewSection(notification: Notification) {
         guard let userInfo = notification.userInfo,
             let index = userInfo["index"] as? Int else { return }
         


### PR DESCRIPTION
> Issue #66 을 해결하였습니다.

fix: reloadData로 섹션 count를 업데이트 해줘서 런타임 에러나는 것 해결함
reloadSection을 쓰더라도 데이터의 일관성을 위해 처음에 reloadData를 한번 해줘야 한다.